### PR TITLE
modularized read_hic_header script

### DIFF
--- a/python/read_hic_header.py
+++ b/python/read_hic_header.py
@@ -5,85 +5,136 @@ import sys
 import struct
 import requests
 import io
+import argparse
 
 def readcstr(f):
-    buf = ""
-    while True:
-        b = f.read(1)
-        b = b.decode('utf-8', 'backslashreplace')
-        if b is None or b == '\0':
-            return str(buf)
-        else:
-            buf = buf + b
+  """
+  Function to parse the requested .hic file.
+  ----------
+  Parameters:
+    f: io.BytesIO object representation of the requested .hic file.
+  ---------- 
+  Returns:
+    string version of the decoded .hic file.
+  """
+  buf = ""
+  while True:
+      b = f.read(1)
+      b = b.decode('utf-8', 'backslashreplace')
+      if b is None or b == '\0':
+        return str(buf)
+      else:
+        buf = buf + b
 #            buf.append(b.decode('utf'))
 
-if (len(sys.argv) != 2 and len(sys.argv) != 3):
-  sys.stderr.write('Usage: '+ sys.argv[0]+' <hic file or URL> [verbose]\n')
-  sys.exit(1)
-verbose=0
+def main(infile:str, verbose:bool=False):
+  """
+  Main function used to read and print the header of a .hic file.
+  ----------
+  Parameters:
+    infile: string path to .hic file (can also be an URL).
+    verbose: boolean indicator of verbosity, default is False.
+  ----------
+  Returns:
+    True if the function ran to completion.
+  ----------
+  Raises:
+    requests.HTTPError: if infile is a URL, but requests.Session.get() returns an invalid (>=400) status code.
+    ValueError: if the header of the .hic file does not contain the 'HIC' keyword.
+  """
+  magic_string = ""
+  if (infile.startswith("http")):
+      # try URL first. 100K should be sufficient for header
+      headers={'range' : 'bytes=0-100000', 'x-amz-meta-requester' : 'straw'}
+      s = requests.Session()
+      r=s.get(infile, headers=headers)
+      if verbose: 
+        print("requested access to:\n" + infile)
+      if (r.status_code >= 400):
+        error_message = "Error accessing\n" + infile + "\nHTTP status code " + str(r.status_code)
+        raise requests.HTTPError(error_message)
+      req=io.BytesIO(r.content)        
+      myrange=r.headers['content-range'].split('/')
+      totalbytes=myrange[1]
+  else:
+      req=open(infile, 'rb')
 
-if (len(sys.argv) == 3):
-  verbose=1
+  magic_string = struct.unpack('<3s', req.read(3))[0]
+  req.read(1)
+  if (magic_string != b"HIC"):
+    error_message = 'This does not appear to be a .hic file; magic string is incorrect'
+    raise ValueError(error_message)
 
-infile = sys.argv[1]
-magic_string = ""
-
-if (infile.startswith("http")):
-    # try URL first. 100K should be sufficient for header
-    headers={'range' : 'bytes=0-100000', 'x-amz-meta-requester' : 'straw'}
-    s = requests.Session()
-    r=s.get(infile, headers=headers)
-    if (r.status_code >=400):
-        print("Error accessing " + infile) 
-        print("HTTP status code " + str(r.status_code))
-        sys.exit(1)
-    req=io.BytesIO(r.content)        
-    myrange=r.headers['content-range'].split('/')
-    totalbytes=myrange[1]
-else:
-    req=open(infile, 'rb')
-
-magic_string = struct.unpack('<3s', req.read(3))[0]
-req.read(1)
-if (magic_string != b"HIC"):
-    print('This does not appear to be a HiC file magic string is incorrect')
-    sys.exit(1)
-version = struct.unpack('<i',req.read(4))[0]
-print('HiC version:')
-print('  {0}'.format(str(version))) 
-masterindex = struct.unpack('<q',req.read(8))[0]
-print('Master index:')
-print('  {0}'.format(str(masterindex)))
-genome = ""
-c=req.read(1).decode("utf-8") 
-while (c != '\0'):
+  version = struct.unpack('<i',req.read(4))[0]
+  if verbose:
+    print('HiC version:')
+    print('  {0}'.format(str(version))) 
+  masterindex = struct.unpack('<q',req.read(8))[0]
+  if verbose:
+    print('Master index:')
+    print('  {0}'.format(str(masterindex)))
+  genome = ""
+  c=req.read(1).decode("utf-8") 
+  while (c != '\0'):
     genome += c
     c=req.read(1).decode("utf-8") 
-print('Genome ID:')
-print('  {0}'.format(str(genome))) 
-# read and throw away attribute dictionary (stats+graphs)
-if (verbose is 1):
+  if verbose:
+    print('Genome ID:')
+    print('  {0}'.format(str(genome))) 
+  # read and throw away attribute dictionary (stats+graphs)
+  if verbose:
     print('Attribute dictionary:')
-nattributes = struct.unpack('<i',req.read(4))[0]
-for x in range(0, nattributes):
-  key = readcstr(req)
-  value = readcstr(req)
-  if (verbose is 1):
-    print('   Key:{0}'.format(key))
-    print('   Value:{0}'.format(value))
-nChrs = struct.unpack('<i',req.read(4))[0]
-print("Chromosomes: ")
-for x in range(0, nChrs):
-  name = readcstr(req)
-  length = struct.unpack('<i',req.read(4))[0]
-  print('  {0}  {1}'.format(name, length))
-nBpRes = struct.unpack('<i',req.read(4))[0]
-print("Base pair-delimited resolutions: ")
-for x in range(0, nBpRes):
-  res = struct.unpack('<i',req.read(4))[0]
-  print('   {0}'.format(res))
-nFrag = struct.unpack('<i',req.read(4))[0]
-print("Fragment-delimited resolutions: ")
-for x in range(0, nFrag):
-  res = struct.unpack('<i',req.read(4))[0]
-  print('   {0}'.format(res))
+  nattributes = struct.unpack('<i',req.read(4))[0]
+  for _ in range(0, nattributes):
+    key = readcstr(req)
+    value = readcstr(req)
+    if verbose:
+      print('   Key:{0}'.format(key))
+      print('   Value:{0}'.format(value))
+  nChrs = struct.unpack('<i',req.read(4))[0]
+  if verbose:
+    print("Chromosomes: ")
+  for _ in range(0, nChrs):
+    name = readcstr(req)
+    length = struct.unpack('<i',req.read(4))[0]
+    if verbose:
+      print('  {0}  {1}'.format(name, length))
+  nBpRes = struct.unpack('<i',req.read(4))[0]
+  if verbose:
+    print("Base pair-delimited resolutions: ")
+  for _ in range(0, nBpRes):
+    res = struct.unpack('<i',req.read(4))[0]
+    if verbose:
+      print('   {0}'.format(res))
+  nFrag = struct.unpack('<i',req.read(4))[0]
+  if verbose:
+    print("Fragment-delimited resolutions: ")
+  for _ in range(0, nFrag):
+    res = struct.unpack('<i',req.read(4))[0]
+    if verbose:
+      print('   {0}'.format(res))
+  req.close()
+  return True 
+
+if __name__ == '__main__':
+
+  parser = argparse.ArgumentParser(
+    prog="read_hic_header", 
+    #usage="python read_hic_header.py <file path/URL> [--silent]", 
+    description="Python script used to read and display the header of .hic files.\nSilent mode (--silent/-s) can be used to parse the file header as a check for .hic file integrity.",
+    formatter_class=argparse.RawTextHelpFormatter
+  )
+  filepath_help_string = '''string path to .hic file (can also be an URL).
+e.g.  read_hic_header.py /home/usr/xyz/hic_files/mm10_wt.hic
+      read_hic_header.py https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC001.hic'''
+
+  silent_help_string = '''boolean switch for silent mode (minimal stdout output, checks file header for file integrity.).
+e.g.  read_hic_header.py /home/usr/xyz/hic_files/mm10_wt.hic -s
+      read_hic_header.py https://hicfiles.s3.amazonaws.com/hiseq/gm12878/in-situ/HIC001.hic --silent'''
+
+  parser.add_argument( 'filepath', type=str, metavar='filepath',
+                      help=filepath_help_string)
+  parser.add_argument( '--silent', '-s', action='store_false', required=False, default=True,
+                      help=silent_help_string)
+  args = parser.parse_args()
+  main(args.filepath, args.silent)  


### PR DESCRIPTION
Motivation: 
There is some code duplication between read_hic_header.py and [straw.__readcstr](https://github.com/aidenlab/straw/blob/80644d9aad555c6d959ea5a311c025a6c5c49aac/python/straw/straw.py#L40) and [straw.read_header](https://github.com/aidenlab/straw/blob/80644d9aad555c6d959ea5a311c025a6c5c49aac/python/straw/straw.py#L53). Maybe a modularized version of the code would make it easier to maintain and update? If this PR is accepted (could use feedback for modifications), straw's Python API could be made more concise.

Changes:

1. replaced argv with argparse functionality
2. refactored script code under main() function
3. code now raises explicit exceptions instead of sys.stderr.write+sys.exit
4. described 'silent' mode
5. filled out docstrings