### PR TITLE
Module for reading header metadata of HiC file as a dictionary

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -61,5 +61,5 @@ Usage: strawObj = straw <hicFile(s)>
 
 See the script [straw.py](https://github.com/theaidenlab/straw/blob/master/python/straw.py) for an example of how to print the results to a file.  
 
-# Read header
+# Read header/metadata
 See the file [read_hic_header.py](https://github.com/theaidenlab/straw/blob/master/python/read_hic_header.py) for a Python script that reads the header of a hic file and outputs the information (including resolutions).

--- a/python/read_hic_header.py
+++ b/python/read_hic_header.py
@@ -16,4 +16,4 @@ verbose=0
 if (len(sys.argv) == 3):
     verbose=1
 
-straw_module.read_metadata(sys.argv[1],verbose=True)
+_=straw_module.read_metadata(sys.argv[1],verbose=False)

--- a/python/read_hic_header.py
+++ b/python/read_hic_header.py
@@ -6,84 +6,14 @@ import struct
 import requests
 import io
 
-def readcstr(f):
-    buf = ""
-    while True:
-        b = f.read(1)
-        b = b.decode('utf-8', 'backslashreplace')
-        if b is None or b == '\0':
-            return str(buf)
-        else:
-            buf = buf + b
-#            buf.append(b.decode('utf'))
+from straw import straw_module
 
 if (len(sys.argv) != 2 and len(sys.argv) != 3):
-  sys.stderr.write('Usage: '+ sys.argv[0]+' <hic file or URL> [verbose]\n')
-  sys.exit(1)
+    sys.stderr.write('Usage: '+ sys.argv[0]+' <hic file or URL> [verbose]\n')
+    sys.exit(1)
 verbose=0
 
 if (len(sys.argv) == 3):
-  verbose=1
+    verbose=1
 
-infile = sys.argv[1]
-magic_string = ""
-
-if (infile.startswith("http")):
-    # try URL first. 100K should be sufficient for header
-    headers={'range' : 'bytes=0-100000', 'x-amz-meta-requester' : 'straw'}
-    s = requests.Session()
-    r=s.get(infile, headers=headers)
-    if (r.status_code >=400):
-        print("Error accessing " + infile) 
-        print("HTTP status code " + str(r.status_code))
-        sys.exit(1)
-    req=io.BytesIO(r.content)        
-    myrange=r.headers['content-range'].split('/')
-    totalbytes=myrange[1]
-else:
-    req=open(infile, 'rb')
-
-magic_string = struct.unpack('<3s', req.read(3))[0]
-req.read(1)
-if (magic_string != b"HIC"):
-    print('This does not appear to be a HiC file magic string is incorrect')
-    sys.exit(1)
-version = struct.unpack('<i',req.read(4))[0]
-print('HiC version:')
-print('  {0}'.format(str(version))) 
-masterindex = struct.unpack('<q',req.read(8))[0]
-print('Master index:')
-print('  {0}'.format(str(masterindex)))
-genome = ""
-c=req.read(1).decode("utf-8") 
-while (c != '\0'):
-    genome += c
-    c=req.read(1).decode("utf-8") 
-print('Genome ID:')
-print('  {0}'.format(str(genome))) 
-# read and throw away attribute dictionary (stats+graphs)
-if (verbose is 1):
-    print('Attribute dictionary:')
-nattributes = struct.unpack('<i',req.read(4))[0]
-for x in range(0, nattributes):
-  key = readcstr(req)
-  value = readcstr(req)
-  if (verbose is 1):
-    print('   Key:{0}'.format(key))
-    print('   Value:{0}'.format(value))
-nChrs = struct.unpack('<i',req.read(4))[0]
-print("Chromosomes: ")
-for x in range(0, nChrs):
-  name = readcstr(req)
-  length = struct.unpack('<i',req.read(4))[0]
-  print('  {0}  {1}'.format(name, length))
-nBpRes = struct.unpack('<i',req.read(4))[0]
-print("Base pair-delimited resolutions: ")
-for x in range(0, nBpRes):
-  res = struct.unpack('<i',req.read(4))[0]
-  print('   {0}'.format(res))
-nFrag = struct.unpack('<i',req.read(4))[0]
-print("Fragment-delimited resolutions: ")
-for x in range(0, nFrag):
-  res = struct.unpack('<i',req.read(4))[0]
-  print('   {0}'.format(res))
+straw_module.read_metadata(sys.argv[1],verbose=True)

--- a/python/read_hic_header.py
+++ b/python/read_hic_header.py
@@ -16,4 +16,4 @@ verbose=0
 if (len(sys.argv) == 3):
     verbose=1
 
-_=straw_module.read_metadata(sys.argv[1],verbose=False)
+_=straw_module.read_metadata(sys.argv[1],verbose=verbose)

--- a/python/straw/straw.py
+++ b/python/straw/straw.py
@@ -84,6 +84,90 @@ class ChromDotSizes:
 
         return chrom, indx1, indx2
 
+def read_metadata(infile,verbose=True):
+    """
+    Reads the metadata of HiC file from header.
+
+    Args
+    infile: str, path to the HiC file 
+    verbose: bool, print the metadata if True else return the metadata
+    
+    Returns
+    metadata: dict, the metadata is returned if verbose is False. 
+                Keys of the metadata: 
+                HiC version, 
+                Master index, 
+                Genome ID (str), 
+                Attribute dictionary (dict), 
+                Chromosomes (dict), 
+                chromosomes2length (dict), 
+                Base pair-delimited resolutions (list), 
+                Fragment-delimited resolutions (list). 
+    """
+    metadata={}
+    import io
+    import struct
+    if (infile.startswith("http")):
+        # try URL first. 100K should be sufficient for header
+        headers={'range' : 'bytes=0-100000', 'x-amz-meta-requester' : 'straw'}
+        s = requests.Session()
+        r=s.get(infile, headers=headers)
+        if (r.status_code >=400):
+            print("Error accessing " + infile) 
+            print("HTTP status code " + str(r.status_code))
+            sys.exit(1)
+        req=io.BytesIO(r.content)        
+        myrange=r.headers['content-range'].split('/')
+        totalbytes=myrange[1]
+    else:
+        req=open(infile, 'rb')
+    magic_string = struct.unpack('<3s', req.read(3))[0]
+    req.read(1)
+    if (magic_string != b"HIC"):
+        sys.exit('This does not appear to be a HiC file magic string is incorrect')
+    version = struct.unpack('<i',req.read(4))[0]
+    metadata['HiC version']=version 
+    masterindex = struct.unpack('<q',req.read(8))[0]
+    metadata['Master index']=masterindex
+    genome = ""
+    c=req.read(1).decode("utf-8") 
+    while (c != '\0'):
+        genome += c
+        c=req.read(1).decode("utf-8") 
+    metadata['Genome ID']=genome        
+    ## read and throw away attribute dictionary (stats+graphs)
+    nattributes = struct.unpack('<i',req.read(4))[0]
+    d={}
+    for x in range(0, nattributes):
+        key = __readcstr(req)
+        value = __readcstr(req)
+        d[key]=value
+    metadata['Attribute dictionary']=d
+    nChrs = struct.unpack('<i',req.read(4))[0]
+    d={}
+    for x in range(0, nChrs):
+        key = __readcstr(req)
+        value = struct.unpack('<i',req.read(4))[0]
+        d[key]=value
+    metadata["Chromosomes"]=d
+    metadata["chromosomes2length"]=metadata["Chromosomes"]
+    nBpRes = struct.unpack('<i',req.read(4))[0]
+    l=[]
+    for x in range(0, nBpRes):
+        res = struct.unpack('<i',req.read(4))[0]
+        l.append(res)
+    metadata["Base pair-delimited resolutions"]=l        
+    nFrag = struct.unpack('<i',req.read(4))[0]
+    l=[]
+    for x in range(0, nFrag):
+        res = struct.unpack('<i',req.read(4))[0]
+        l.append(res)
+    metadata["Fragment-delimited resolutions"]=l 
+    if verbose:
+        for k in metadata:
+            print(k,':',metadata[k])
+    else:
+        return metadata    
 
 def readHeader(infile, is_synapse):
     """ Reads the header

--- a/python/straw/straw.py
+++ b/python/straw/straw.py
@@ -84,23 +84,22 @@ class ChromDotSizes:
 
         return chrom, indx1, indx2
 
-def read_metadata(infile,verbose=True):
+def read_metadata(infile,verbose=False):
     """
     Reads the metadata of HiC file from header.
 
     Args
     infile: str, path to the HiC file 
-    verbose: bool, print the metadata if True else return the metadata
+    verbose: bool
     
     Returns
-    metadata: dict, the metadata is returned if verbose is False. 
+    metadata: dict, containing the metadata. 
                 Keys of the metadata: 
                 HiC version, 
                 Master index, 
                 Genome ID (str), 
                 Attribute dictionary (dict), 
                 Chromosomes (dict), 
-                chromosomes2length (dict), 
                 Base pair-delimited resolutions (list), 
                 Fragment-delimited resolutions (list). 
     """
@@ -150,7 +149,6 @@ def read_metadata(infile,verbose=True):
         value = struct.unpack('<i',req.read(4))[0]
         d[key]=value
     metadata["Chromosomes"]=d
-    metadata["chromosomes2length"]=metadata["Chromosomes"]
     nBpRes = struct.unpack('<i',req.read(4))[0]
     l=[]
     for x in range(0, nBpRes):
@@ -163,11 +161,11 @@ def read_metadata(infile,verbose=True):
         res = struct.unpack('<i',req.read(4))[0]
         l.append(res)
     metadata["Fragment-delimited resolutions"]=l 
+    for k in metadata:
+        print(k,':',metadata[k])
     if verbose:
-        for k in metadata:
-            print(k,':',metadata[k])
-    else:
-        return metadata    
+        print('Attribute dictionary',':',metadata['Attribute dictionary'])        
+    return metadata    
 
 def readHeader(infile, is_synapse):
     """ Reads the header

--- a/python/straw/straw.py
+++ b/python/straw/straw.py
@@ -162,7 +162,8 @@ def read_metadata(infile,verbose=False):
         l.append(res)
     metadata["Fragment-delimited resolutions"]=l 
     for k in metadata:
-        print(k,':',metadata[k])
+        if k!='Attribute dictionary':
+            print(k,':',metadata[k])
     if verbose:
         print('Attribute dictionary',':',metadata['Attribute dictionary'])        
     return metadata    


### PR DESCRIPTION
Hi, 
[I wanted to read the header metadata of a HiC file as a dictionary](https://bioinformatics.stackexchange.com/q/12844/274), so 
1. I organised the code in `python/read_hic_header.py` and created a module named `read_metadata` in `python/straw/straw.py`.
2. Cleaned the `python/read_hic_header.py` script and simply added a call to the new `read_metadata` module.

I tested `python/read_hic_header.py` and it works just the way it was working earlier.
This modification would be of help to some who would like to check the metadata of the file before digging into it.

Rohan
