### PR TITLE
added else-block for if-block on line #699

### DIFF
--- a/python/straw/straw.py
+++ b/python/straw/straw.py
@@ -703,7 +703,7 @@ class straw:
             else:
                 c2Norm = futureNorm2.result()
         else:
-            c1Norm, c1Norm = None, None
+            c1Norm, c2Norm = None, None
             
         blockBinCount, blockColumnCount = futureMatrix.result()
         return normalizedmatrix(self.infile, self.is_synapse, binsize, isIntra, neededToFlipIndices, blockBinCount,

--- a/python/straw/straw.py
+++ b/python/straw/straw.py
@@ -702,6 +702,9 @@ class straw:
                 c2Norm = c1Norm
             else:
                 c2Norm = futureNorm2.result()
+        else:
+            c1Norm, c1Norm = None, None
+            
         blockBinCount, blockColumnCount = futureMatrix.result()
         return normalizedmatrix(self.infile, self.is_synapse, binsize, isIntra, neededToFlipIndices, blockBinCount,
                                 blockColumnCount, blockMap, norm, c1Norm, c2Norm, self.version)


### PR DESCRIPTION
Added missing else-block for the if-block ```if norm != "NONE":``` on line #699. Added else-block sets ```c1Norm``` and ```c2Norm``` to ```None```. 

Calls to ```c1Norm``` and ```c2Norm``` include those in:
- ```normalizematrix.__init__``` (which sets ```c1Norm``` and ```c2Norm``` as instance parameters)
- ```normalizematrix.getDataFromBinRegion``` (which passed ```c1Norm``` and ```c2Norm``` as arguments to multiprocessed calls to ```readBlockWorker```)
- ```readBlockWorker``` (which only uses ```c1Norm``` and ```c2Norm``` in an if-block: ```if norm != "NONE"```)

This would resolve https://github.com/aidenlab/straw/issues/45