### PR TITLE
Add `matrix` parameter to extract `oe` data

### DIFF
--- a/C++/main.cpp
+++ b/C++/main.cpp
@@ -1,18 +1,18 @@
 /*
   The MIT License (MIT)
- 
+
   Copyright (c) 2011-2016 Broad Institute, Aiden Lab
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -46,6 +46,6 @@ int main(int argc, char *argv[])
   records = straw(norm, fname, chr1loc, chr2loc, unit, binsize);
   int length=records.size();
   for (int i=0; i<length; i++) {
-    printf("%d\t%d\t%.14g\n", records[i].binX, records[i].binY, records[i].counts);   
+    printf("%d\t%d\t%.14g\n", records[i].binX, records[i].binY, records[i].counts);
   }
 }

--- a/C++/main.cpp
+++ b/C++/main.cpp
@@ -28,22 +28,23 @@ using namespace std;
 
 int main(int argc, char *argv[])
 {
-  if (argc != 7) {
+  if (argc != 8) {
     cerr << "Not enough arguments" << endl;
-    cerr << "Usage: straw <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>" << endl;
+    cerr << "Usage: straw <observed/oe> <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>" << endl;
     exit(1);
   }
 
-  string norm=argv[1];
-  string fname=argv[2];
-  string chr1loc=argv[3];
-  string chr2loc=argv[4];
-  string unit=argv[5];
-  string size=argv[6];
+  string matrix=argv[1];
+  string norm=argv[2];
+  string fname=argv[3];
+  string chr1loc=argv[4];
+  string chr2loc=argv[5];
+  string unit=argv[6];
+  string size=argv[7];
   int binsize=stoi(size);
   vector<contactRecord> records;
 
-  records = straw(norm, fname, chr1loc, chr2loc, unit, binsize);
+  records = straw(matrix, norm, fname, chr1loc, chr2loc, unit, binsize);
   int length=records.size();
   for (int i=0; i<length; i++) {
     printf("%d\t%d\t%.14g\n", records[i].binX, records[i].binY, records[i].counts);

--- a/C++/straw.cpp
+++ b/C++/straw.cpp
@@ -922,7 +922,6 @@ vector<contactRecord> straw(string matrix, string norm, string fname, string chr
     // readMatrix will assign blockBinCount and blockColumnCount
     blockMap = readMatrix(fin, myFilePos, unit, binsize, sumCounts, blockBinCount, blockColumnCount);
   }
-
   double avgCount;
   if (c1 != c2) {
     long nBins1 = chromosomeMap[chr1].length / binsize;

--- a/C++/straw.cpp
+++ b/C++/straw.cpp
@@ -1,18 +1,18 @@
 /*
   The MIT License (MIT)
- 
+
   Copyright (c) 2011-2016 Broad Institute, Aiden Lab
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -43,7 +43,7 @@ using namespace std;
 
   Currently only supporting matrices.
 
-  Usage: straw <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize> 
+  Usage: straw <NONE/VC/VC_SQRT/KR/OE> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>
  */
 // this is for creating a stream from a byte array for ease of use
 struct membuf : std::streambuf
@@ -90,35 +90,35 @@ WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
   struct MemoryStruct *mem = (struct MemoryStruct *)userp;
- 
+
   mem->memory = static_cast<char*>(realloc(mem->memory, mem->size + realsize + 1));
   if(mem->memory == NULL) {
-    /* out of memory! */ 
+    /* out of memory! */
     printf("not enough memory (realloc returned NULL)\n");
     return 0;
   }
- 
+
   std::memcpy(&(mem->memory[mem->size]), contents, realsize);
   mem->size += realsize;
   mem->memory[mem->size] = 0;
- 
+
   return realsize;
 }
 
 // get a buffer that can be used as an input stream from the URL
 char* getData(CURL *curl, long position, int chunksize) {
   std::ostringstream oss;
-  struct MemoryStruct chunk; 
+  struct MemoryStruct chunk;
 
-  chunk.memory = static_cast<char*>(malloc(1)); 
-  chunk.size = 0;    /* no data at this point */ 
+  chunk.memory = static_cast<char*>(malloc(1));
+  chunk.size = 0;    /* no data at this point */
   oss << position << "-" << position + chunksize;
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
   curl_easy_setopt(curl, CURLOPT_RANGE, oss.str().c_str());
   CURLcode res = curl_easy_perform(curl);
   if (res != CURLE_OK) {
     fprintf(stderr, "curl_easy_perform() failed: %s\n",
-	    curl_easy_strerror(res));    
+	    curl_easy_strerror(res));
   }
   //  printf("%lu bytes retrieved\n", (long)chunk.size);
 
@@ -131,7 +131,7 @@ CURL* initCURL(const char* url) {
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
     curl_easy_setopt(curl, CURLOPT_URL, url);
-    //curl_easy_setopt (curl, CURLOPT_VERBOSE, 1L); 
+    //curl_easy_setopt (curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, hdf);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "straw");
@@ -191,16 +191,16 @@ map<string, chromosome> readHeader(istream& fin, long& master) {
 }
 
 // reads the footer from the master pointer location. takes in the chromosomes,
-// norm, unit (BP or FRAG) and resolution or binsize, and sets the file 
-// position of the matrix and the normalization vectors for those chromosomes 
+// norm, unit (BP or FRAG) and resolution or binsize, and sets the file
+// position of the matrix and the normalization vectors for those chromosomes
 // at the given normalization and resolution
-bool readFooter(istream& fin, long master, int c1, int c2, string norm, string unit, int resolution, long &myFilePos, indexEntry &c1NormEntry, indexEntry &c2NormEntry) {
+bool readFooter(istream& fin, long master, int c1, int c2, string norm, string unit, int resolution, long &myFilePos, indexEntry &c1NormEntry, indexEntry &c2NormEntry, vector<double> &expectedValues) {
   int nBytes;
   fin.read((char*)&nBytes, sizeof(int));
   stringstream ss;
   ss << c1 << "_" << c2;
   string key = ss.str();
-  
+
   int nEntries;
   fin.read((char*)&nEntries, sizeof(int));
   bool found = false;
@@ -222,8 +222,8 @@ bool readFooter(istream& fin, long master, int c1, int c2, string norm, string u
   }
 
   if (norm=="NONE") return true; // no need to read norm vector index
- 
-  // read in and ignore expected value maps; don't store; reading these to 
+
+  // read in and ignore expected value maps; don't store; reading these to
   // get to norm vector index
   int nExpectedValues;
   fin.read((char*)&nExpectedValues, sizeof(int));
@@ -235,9 +235,13 @@ bool readFooter(istream& fin, long master, int c1, int c2, string norm, string u
 
     int nValues;
     fin.read((char*)&nValues, sizeof(int));
+    bool store = c1 == c2 && str == unit && binSize == resolution;
     for (int j=0; j<nValues; j++) {
       double v;
       fin.read((char*)&v, sizeof(double));
+      if (store) {
+        expectedValues.push_back(v);
+      }
     }
 
     int nNormalizationFactors;
@@ -247,7 +251,18 @@ bool readFooter(istream& fin, long master, int c1, int c2, string norm, string u
       fin.read((char*)&chrIdx, sizeof(int));
       double v;
       fin.read((char*)&v, sizeof(double));
+      if (store && chrIdx == c1) {
+        for (vector<double>::iterator it=expectedValues.begin(); it!=expectedValues.end(); ++it) {
+          *it = *it / v;
+        }
+      }
     }
+  }
+  if (norm == "OE") {
+    if (c1 == c2 && expectedValues.size() == 0) {
+      cerr << "File did not contain expected values vectors at " << resolution << " " << unit << endl;
+    }
+    return true;
   }
   fin.read((char*)&nExpectedValues, sizeof(int));
   for (int i=0; i<nExpectedValues; i++) {
@@ -306,16 +321,17 @@ bool readFooter(istream& fin, long master, int c1, int c2, string norm, string u
   return true;
 }
 
-// reads the raw binned contact matrix at specified resolution, setting the block bin count and block column count 
-map <int, indexEntry> readMatrixZoomData(istream& fin, string myunit, int mybinsize, int &myBlockBinCount, int &myBlockColumnCount, bool &found) {
-  
+// reads the raw binned contact matrix at specified resolution, setting the block bin count and block column count
+map <int, indexEntry> readMatrixZoomData(istream& fin, string myunit, int mybinsize, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount, bool &found) {
+
   map <int, indexEntry> blockMap;
   string unit;
   getline(fin, unit, '\0' ); // unit
   int tmp;
   fin.read((char*)&tmp, sizeof(int)); // Old "zoom" index -- not used
+  float sumCounts;
+  fin.read((char*)&sumCounts, sizeof(float)); // sumCounts
   float tmp2;
-  fin.read((char*)&tmp2, sizeof(float)); // sumCounts
   fin.read((char*)&tmp2, sizeof(float)); // occupiedCellCount
   fin.read((char*)&tmp2, sizeof(float)); // stdDev
   fin.read((char*)&tmp2, sizeof(float)); // percent95
@@ -325,9 +341,10 @@ map <int, indexEntry> readMatrixZoomData(istream& fin, string myunit, int mybins
   fin.read((char*)&blockBinCount, sizeof(int));
   int blockColumnCount;
   fin.read((char*)&blockColumnCount, sizeof(int));
-  
+
   found = false;
   if (myunit==unit && mybinsize==binSize) {
+    mySumCounts = sumCounts;
     myBlockBinCount = blockBinCount;
     myBlockColumnCount = blockColumnCount;
     found = true;
@@ -351,8 +368,8 @@ map <int, indexEntry> readMatrixZoomData(istream& fin, string myunit, int mybins
   return blockMap;
 }
 
-// reads the raw binned contact matrix at specified resolution, setting the block bin count and block column count 
-map <int, indexEntry> readMatrixZoomDataHttp(CURL* curl, long &myFilePosition, string myunit, int mybinsize, int &myBlockBinCount, int &myBlockColumnCount, bool &found) {
+// reads the raw binned contact matrix at specified resolution, setting the block bin count and block column count
+map <int, indexEntry> readMatrixZoomDataHttp(CURL* curl, long &myFilePosition, string myunit, int mybinsize, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount, bool &found) {
 
   map <int, indexEntry> blockMap;
   char* buffer;
@@ -377,8 +394,9 @@ map <int, indexEntry> readMatrixZoomDataHttp(CURL* curl, long &myFilePosition, s
   getline(fin, unit, '\0' ); // unit
   int tmp;
   fin.read((char*)&tmp, sizeof(int)); // Old "zoom" index -- not used
+  float sumCounts;
+  fin.read((char*)&sumCounts, sizeof(float)); // sumCounts
   float tmp2;
-  fin.read((char*)&tmp2, sizeof(float)); // sumCounts
   fin.read((char*)&tmp2, sizeof(float)); // occupiedCellCount
   fin.read((char*)&tmp2, sizeof(float)); // stdDev
   fin.read((char*)&tmp2, sizeof(float)); // percent95
@@ -391,11 +409,12 @@ map <int, indexEntry> readMatrixZoomDataHttp(CURL* curl, long &myFilePosition, s
 
   found = false;
   if (myunit==unit && mybinsize==binSize) {
+    mySumCounts = sumCounts;
     myBlockBinCount = blockBinCount;
     myBlockColumnCount = blockColumnCount;
     found = true;
   }
-  
+
   int nBlocks;
   fin.read((char*)&nBlocks, sizeof(int));
 
@@ -425,7 +444,7 @@ map <int, indexEntry> readMatrixZoomDataHttp(CURL* curl, long &myFilePosition, s
 
 // goes to the specified file pointer in http and finds the raw contact matrix at specified resolution, calling readMatrixZoomData.
 // sets blockbincount and blockcolumncount
-map <int, indexEntry> readMatrixHttp(CURL *curl, long myFilePosition, string unit, int resolution, int &myBlockBinCount, int &myBlockColumnCount) {
+map <int, indexEntry> readMatrixHttp(CURL *curl, long myFilePosition, string unit, int resolution, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount) {
   char * buffer;
   int size = sizeof(int)*3;
   buffer = getData(curl, myFilePosition, size);
@@ -445,7 +464,7 @@ map <int, indexEntry> readMatrixHttp(CURL *curl, long myFilePosition, string uni
 
   while (i<nRes && !found) {
     // myFilePosition gets updated within call
-    blockMap = readMatrixZoomDataHttp(curl, myFilePosition, unit, resolution, myBlockBinCount, myBlockColumnCount, found);
+    blockMap = readMatrixZoomDataHttp(curl, myFilePosition, unit, resolution, mySumCounts, myBlockBinCount, myBlockColumnCount, found);
     i++;
   }
   if (!found) {
@@ -456,7 +475,7 @@ map <int, indexEntry> readMatrixHttp(CURL *curl, long myFilePosition, string uni
 
 // goes to the specified file pointer and finds the raw contact matrix at specified resolution, calling readMatrixZoomData.
 // sets blockbincount and blockcolumncount
-map <int, indexEntry> readMatrix(istream& fin, long myFilePosition, string unit, int resolution, int &myBlockBinCount, int &myBlockColumnCount) {
+map <int, indexEntry> readMatrix(istream& fin, long myFilePosition, string unit, int resolution, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount) {
   map <int, indexEntry> blockMap;
 
   fin.seekg(myFilePosition, ios::beg);
@@ -468,7 +487,7 @@ map <int, indexEntry> readMatrix(istream& fin, long myFilePosition, string unit,
   int i=0;
   bool found=false;
   while (i<nRes && !found) {
-    blockMap = readMatrixZoomData(fin, unit, resolution, myBlockBinCount, myBlockColumnCount, found);
+    blockMap = readMatrixZoomData(fin, unit, resolution, mySumCounts, myBlockBinCount, myBlockColumnCount, found);
     i++;
   }
   if (!found) {
@@ -483,7 +502,7 @@ set<int> getBlockNumbersForRegionFromBinPosition(int* regionIndices, int blockBi
    int col2 = (regionIndices[1] + 1) / blockBinCount;
    int row1 = regionIndices[2] / blockBinCount;
    int row2 = (regionIndices[3] + 1) / blockBinCount;
-   
+
    set<int> blocksSet;
    // first check the upper triangular matrix
    for (int r = row1; r <= row2; r++) {
@@ -517,7 +536,7 @@ vector<contactRecord> readBlock(istream& fin, CURL* curl, bool isHttp, indexEntr
   char* uncompressedBytes = new char[idx.size*10]; //biggest seen so far is 3
 
   if (isHttp) {
-    compressedBytes = getData(curl, idx.position, idx.size);    
+    compressedBytes = getData(curl, idx.position, idx.size);
   }
   else {
     fin.seekg(idx.position, ios::beg);
@@ -559,7 +578,7 @@ vector<contactRecord> readBlock(istream& fin, CURL* curl, bool isHttp, indexEntr
       record.counts = counts;
       v[i] = record;
     }
-  } 
+  }
   else {
     int binXOffset, binYOffset;
     bufferin.read((char*)&binXOffset, sizeof(int));
@@ -588,7 +607,7 @@ vector<contactRecord> readBlock(istream& fin, CURL* curl, bool isHttp, indexEntr
 	    short c;
 	    bufferin.read((char*)&c, sizeof(short));
 	    counts = c;
-	  } 
+	  }
 	  else {
 	    bufferin.read((char*)&counts, sizeof(float));
 	  }
@@ -626,7 +645,7 @@ vector<contactRecord> readBlock(istream& fin, CURL* curl, bool isHttp, indexEntr
 	    v[index]=record;
 	    index++;
 	  }
-	} 
+	}
 	else {
 	  bufferin.read((char*)&counts, sizeof(float));
 	  if (!isnan(counts)) {
@@ -651,10 +670,10 @@ int readSize(istream& fin, CURL* curl, bool isHttp, indexEntry idx) {
     return 0;
   }
   char* compressedBytes = new char[idx.size];
-  char* uncompressedBytes = new char[idx.size*10]; 
+  char* uncompressedBytes = new char[idx.size*10];
 
   if (isHttp) {
-    compressedBytes = getData(curl, idx.position, idx.size);    
+    compressedBytes = getData(curl, idx.position, idx.size);
   }
   else {
     fin.seekg(idx.position, ios::beg);
@@ -709,8 +728,8 @@ vector<double> readNormalizationVector(istream& bufferin) {
 vector<contactRecord> straw(string norm, string fname, string chr1loc, string chr2loc, string unit, int binsize)
 {
   if (!(unit=="BP"||unit=="FRAG")) {
-    cerr << "Norm specified incorrectly, must be one of <BP/FRAG>" << endl; 
-    cerr << "Usage: straw <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>" << endl;
+    cerr << "Norm specified incorrectly, must be one of <BP/FRAG>" << endl;
+    cerr << "Usage: straw <NONE/VC/VC_SQRT/KR/OE> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>" << endl;
     vector<contactRecord> v;
     return v;
   }
@@ -731,17 +750,17 @@ vector<contactRecord> straw(string norm, string fname, string chr1loc, string ch
     char * buffer;
     curl = initCURL(fname.c_str());
     if (curl) {
-      buffer = getData(curl, 0, 100000);    
+      buffer = getData(curl, 0, 100000);
     }
     else {
       cerr << "URL " << fname << " cannot be opened for reading" << endl;
       vector<contactRecord> v;
       return v;
     }
-    membuf sbuf(buffer, buffer + 100000); 
-    istream bufin(&sbuf);  
+    membuf sbuf(buffer, buffer + 100000);
+    istream bufin(&sbuf);
     chromosomeMap = readHeader(bufin, master);
-    delete buffer;    
+    delete buffer;
   }
   else {
     fin.open(fname, fstream::in);
@@ -778,12 +797,12 @@ vector<contactRecord> straw(string norm, string fname, string chr1loc, string ch
     cerr << chr2 << " not found in the file." << endl;
     vector<contactRecord> v;
     return v;
-  }  
+  }
 
   if (getline(ss1, x, ':') && getline(ss1, y, ':')) {
     c2pos1 = stoi(x);
     c2pos2 = stoi(y);
-  }  
+  }
   else {
     c2pos1 = 0;
     c2pos2 = chromosomeMap[chr2].length;
@@ -818,20 +837,21 @@ vector<contactRecord> straw(string norm, string fname, string chr1loc, string ch
 
   indexEntry c1NormEntry, c2NormEntry;
   long myFilePos;
+  vector<double> expectedValues;
 
   long bytes_to_read = total_bytes - master;
   bool foundFooter = false;
   if (isHttp) {
     char* buffer2;
-    buffer2 = getData(curl, master, bytes_to_read);    
+    buffer2 = getData(curl, master, bytes_to_read);
     membuf sbuf2(buffer2, buffer2 + bytes_to_read);
     istream bufin2(&sbuf2);
-    foundFooter = readFooter(bufin2, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry); 
+    foundFooter = readFooter(bufin2, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry, expectedValues);
     delete buffer2;
   }
-  else { 
+  else {
     fin.seekg(master, ios::beg);
-    foundFooter = readFooter(fin, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry); 
+    foundFooter = readFooter(fin, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry, expectedValues);
   }
   // readFooter will assign the above variables
 
@@ -843,7 +863,7 @@ vector<contactRecord> straw(string norm, string fname, string chr1loc, string ch
   vector<double> c1Norm;
   vector<double> c2Norm;
 
-  if (norm != "NONE") {
+  if (norm != "OE" && norm != "NONE") {
     char* buffer3;
     if (isHttp) {
       buffer3 = getData(curl, c1NormEntry.position, c1NormEntry.size);
@@ -873,19 +893,26 @@ vector<contactRecord> straw(string norm, string fname, string chr1loc, string ch
     delete buffer4;
   }
 
+  float sumCounts;
   int blockBinCount, blockColumnCount;
   map<int, indexEntry> blockMap;
 
   if (isHttp) {
     // readMatrix will assign blockBinCount and blockColumnCount
-    blockMap = readMatrixHttp(curl, myFilePos, unit, binsize, blockBinCount, blockColumnCount); 
+    blockMap = readMatrixHttp(curl, myFilePos, unit, binsize, sumCounts, blockBinCount, blockColumnCount);
   }
   else {
     // readMatrix will assign blockBinCount and blockColumnCount
-    blockMap = readMatrix(fin, myFilePos, unit, binsize, blockBinCount, blockColumnCount); 
+    blockMap = readMatrix(fin, myFilePos, unit, binsize, sumCounts, blockBinCount, blockColumnCount);
+  }
+  double avgCount;
+  if (c1 != c2) {
+    long nBins1 = chromosomeMap[chr1].length / binsize;
+    long nBins2 = chromosomeMap[chr2].length / binsize;
+    avgCount = (sumCounts / nBins1) / nBins2;   // <= trying to avoid overflows
   }
 
-  set<int> blockNumbers = getBlockNumbersForRegionFromBinPosition(regionIndices, blockBinCount, blockColumnCount, c1==c2); 
+  set<int> blockNumbers = getBlockNumbersForRegionFromBinPosition(regionIndices, blockBinCount, blockColumnCount, c1==c2);
 
   // getBlockIndices
   vector<contactRecord> records;
@@ -895,12 +922,20 @@ vector<contactRecord> straw(string norm, string fname, string chr1loc, string ch
     tmp_records = readBlock(fin, curl, isHttp, blockMap[*it]);
     for (vector<contactRecord>::iterator it2=tmp_records.begin(); it2!=tmp_records.end(); ++it2) {
       contactRecord rec = *it2;
-      
+
       int x = rec.binX * binsize;
       int y = rec.binY * binsize;
       float c = rec.counts;
-      if (norm != "NONE") {
-	c = c / (c1Norm[rec.binX] * c2Norm[rec.binY]);
+      if (norm == "OE") {
+        if (c1 == c2) {
+          c = c / expectedValues[min(expectedValues.size() - 1, (size_t)floor(abs(y - x) / binsize))];
+        }
+        else {
+          c = c / avgCount;
+        }
+      }
+      else if (norm != "NONE") {
+        c = c / (c1Norm[rec.binX] * c2Norm[rec.binY]);
       }
 
       if ((x >= origRegionIndices[0] && x <= origRegionIndices[1] &&
@@ -916,7 +951,7 @@ vector<contactRecord> straw(string norm, string fname, string chr1loc, string ch
       }
     }
   }
-      //      free(chunk.memory);      
+      //      free(chunk.memory);
       /* always cleanup */
       // curl_easy_cleanup(curl);
       //    curl_global_cleanup();
@@ -927,8 +962,8 @@ vector<contactRecord> straw(string norm, string fname, string chr1loc, string ch
 int getSize(string norm, string fname, string chr1loc, string chr2loc, string unit, int binsize)
 {
   if (!(unit=="BP"||unit=="FRAG")) {
-    cerr << "Norm specified incorrectly, must be one of <BP/FRAG>" << endl; 
-    cerr << "Usage: straw <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>" << endl;
+    cerr << "Norm specified incorrectly, must be one of <BP/FRAG>" << endl;
+    cerr << "Usage: straw <NONE/VC/VC_SQRT/KR/OE> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>" << endl;
     return 0;
   }
 
@@ -947,14 +982,14 @@ int getSize(string norm, string fname, string chr1loc, string chr2loc, string un
     char * buffer;
     curl = initCURL(fname.c_str());
     if (curl) {
-      buffer = getData(curl, 0, 100000);    
+      buffer = getData(curl, 0, 100000);
     }
     else {
       cerr << "URL " << fname << " cannot be opened for reading" << endl;
       return 0;
     }
-    membuf sbuf(buffer, buffer + 100000); 
-    istream bufin(&sbuf);  
+    membuf sbuf(buffer, buffer + 100000);
+    istream bufin(&sbuf);
     chromosomeMap = readHeader(bufin, master);
     delete buffer;
   }
@@ -990,11 +1025,11 @@ int getSize(string norm, string fname, string chr1loc, string chr2loc, string un
   if (chromosomeMap.count(chr2) == 0) {
     cerr << chr2 << " not found in the file." << endl;
     return 0;
-  }  
+  }
   if (getline(ss1, x, ':') && getline(ss1, y, ':')) {
     c2pos1 = stoi(x);
     c2pos2 = stoi(y);
-  }  
+  }
   else {
     c2pos1 = 0;
     c2pos2 = chromosomeMap[chr2].length;
@@ -1029,21 +1064,22 @@ int getSize(string norm, string fname, string chr1loc, string chr2loc, string un
 
   indexEntry c1NormEntry, c2NormEntry;
   long myFilePos;
+  vector<double> expectedValues;
 
   long bytes_to_read = total_bytes - master;
   bool foundFooter = false;
 
   if (isHttp) {
     char* buffer2;
-    buffer2 = getData(curl, master, bytes_to_read);    
+    buffer2 = getData(curl, master, bytes_to_read);
     membuf sbuf2(buffer2, buffer2 + bytes_to_read);
     istream bufin2(&sbuf2);
-    foundFooter = readFooter(bufin2, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry); 
+    foundFooter = readFooter(bufin2, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry, expectedValues);
     delete buffer2;
   }
-  else { 
+  else {
     fin.seekg(master, ios::beg);
-    foundFooter = readFooter(fin, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry); 
+    foundFooter = readFooter(fin, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry, expectedValues);
   }
   // readFooter will assign the above variables
 
@@ -1052,7 +1088,7 @@ int getSize(string norm, string fname, string chr1loc, string chr2loc, string un
   vector<double> c1Norm;
   vector<double> c2Norm;
 
-  if (norm != "NONE") {
+  if (norm != "OE" && norm != "NONE") {
     char* buffer3;
     if (isHttp) {
       buffer3 = getData(curl, c1NormEntry.position, c1NormEntry.size);
@@ -1082,17 +1118,18 @@ int getSize(string norm, string fname, string chr1loc, string chr2loc, string un
     delete buffer4;
   }
 
+  float sumCounts;
   int blockBinCount, blockColumnCount;
   map<int, indexEntry> blockMap;
   if (isHttp) {
     // readMatrix will assign blockBinCount and blockColumnCount
-    blockMap = readMatrixHttp(curl, myFilePos, unit, binsize, blockBinCount, blockColumnCount); 
+    blockMap = readMatrixHttp(curl, myFilePos, unit, binsize, sumCounts, blockBinCount, blockColumnCount);
   }
   else {
     // readMatrix will assign blockBinCount and blockColumnCount
-    blockMap = readMatrix(fin, myFilePos, unit, binsize, blockBinCount, blockColumnCount); 
+    blockMap = readMatrix(fin, myFilePos, unit, binsize, sumCounts, blockBinCount, blockColumnCount);
   }
-  set<int> blockNumbers = getBlockNumbersForRegionFromBinPosition(regionIndices, blockBinCount, blockColumnCount, c1==c2); 
+  set<int> blockNumbers = getBlockNumbersForRegionFromBinPosition(regionIndices, blockBinCount, blockColumnCount, c1==c2);
 
   // getBlockIndices
   vector<contactRecord> tmp_records;
@@ -1103,5 +1140,3 @@ int getSize(string norm, string fname, string chr1loc, string chr2loc, string un
   }
   return count;
 }
-
-

--- a/C++/straw.h
+++ b/C++/straw.h
@@ -51,12 +51,12 @@ struct chromosome {
 
 bool readMagicString(std::ifstream& fin);
 std::map<std::string, chromosome> readHeader(std::istream& fin, long &master);
-bool readFooter(std::istream& fin, long master, int c1, int c2, std::string norm, std::string unit, int resolution, long &myFilePos, indexEntry &c1NormEntry, indexEntry &c2NormEntry, std::vector<double> &expectedValues);
+bool readFooter(std::istream& fin, long master, int c1, int c2, std::string matrix, std::string norm, std::string unit, int resolution, long &myFilePos, indexEntry &c1NormEntry, indexEntry &c2NormEntry, std::vector<double> &expectedValues);
 std::map<int, indexEntry> readMatrixZoomData(std::istream& fin, std::string myunit, int mybinsize, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount, bool &found);
 std::map<int, indexEntry> readMatrix(std::istream& fin, int myFilePosition, std::string unit, int resolution, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount);
 std::set<int> getBlockNumbersForRegionFromBinPosition(int* regionIndices, int blockBinCount, int blockColumnCount, bool intra);
 std::vector<contactRecord> readBlock(std::istream& fin, int blockNumber);
 std::vector<double> readNormalizationVector(std::istream& fin, indexEntry entry);
-std::vector<contactRecord> straw(std::string norm, std::string fname, std::string chr1loc, std::string chr2loc, std::string unit, int binsize);
-int getSize(std::string norm, std::string fname, std::string chr1loc, std::string chr2loc, std::string unit, int binsize);
+std::vector<contactRecord> straw(std::string matrix, std::string norm, std::string fname, std::string chr1loc, std::string chr2loc, std::string unit, int binsize);
+int getSize(std::string matrix, std::string norm, std::string fname, std::string chr1loc, std::string chr2loc, std::string unit, int binsize);
 #endif

--- a/C++/straw.h
+++ b/C++/straw.h
@@ -1,18 +1,18 @@
 /*
   The MIT License (MIT)
- 
+
   Copyright (c) 2011-2016 Broad Institute, Aiden Lab
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,7 +29,7 @@
 #include <vector>
 #include <map>
 
-// pointer structure for reading blocks or matrices, holds the size and position 
+// pointer structure for reading blocks or matrices, holds the size and position
 struct indexEntry {
   int size;
   long position;
@@ -51,9 +51,9 @@ struct chromosome {
 
 bool readMagicString(std::ifstream& fin);
 std::map<std::string, chromosome> readHeader(std::istream& fin, long &master);
-bool readFooter(std::istream& fin, long master, int c1, int c2, std::string norm, std::string unit, int resolution, long &myFilePos, indexEntry &c1NormEntry, indexEntry &c2NormEntry);
-std::map<int, indexEntry> readMatrixZoomData(std::istream& fin, std::string myunit, int mybinsize, int &myBlockBinCount, int &myBlockColumnCount, bool &found);
-std::map<int, indexEntry> readMatrix(std::istream& fin, int myFilePosition, std::string unit, int resolution, int &myBlockBinCount, int &myBlockColumnCount);
+bool readFooter(std::istream& fin, long master, int c1, int c2, std::string norm, std::string unit, int resolution, long &myFilePos, indexEntry &c1NormEntry, indexEntry &c2NormEntry, std::vector<double> &expectedValues);
+std::map<int, indexEntry> readMatrixZoomData(std::istream& fin, std::string myunit, int mybinsize, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount, bool &found);
+std::map<int, indexEntry> readMatrix(std::istream& fin, int myFilePosition, std::string unit, int resolution, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount);
 std::set<int> getBlockNumbersForRegionFromBinPosition(int* regionIndices, int blockBinCount, int blockColumnCount, bool intra);
 std::vector<contactRecord> readBlock(std::istream& fin, int blockNumber);
 std::vector<double> readNormalizationVector(std::istream& fin, indexEntry entry);

--- a/R/R/RcppExports.R
+++ b/R/R/RcppExports.R
@@ -8,8 +8,9 @@
 #' of data, and outputs as data.frame in sparse upper triangular format.
 #' Currently only supporting matrices.
 #' 
-#' Usage: straw <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>
-#' 
+#' Usage: straw <observed/oe> <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>
+#' @param matrix Type of matrix to output. Must be one of observed/oe.
+#'     observed is observed counts, oe is observed/expected counts.
 #' @param norm Normalization to apply. Must be one of NONE/VC/VC_SQRT/KR.
 #'     VC is vanilla coverage, VC_SQRT is square root of vanilla coverage, and KR is Knight-Ruiz or
 #'     Balanced normalization.
@@ -22,7 +23,7 @@
 #'     100, 50, 20, 5, 2, 1>.
 #' @return Data.frame of a sparse matrix of data from hic file. x,y,counts
 #' @export
-straw <- function(norm, fname, chr1loc, chr2loc, unit, binsize) {
-    .Call('_strawr_straw', PACKAGE = 'strawr', norm, fname, chr1loc, chr2loc, unit, binsize)
+straw <- function(matrix, norm, fname, chr1loc, chr2loc, unit, binsize) {
+    .Call('_strawr_straw', PACKAGE = 'strawr', matrix, norm, fname, chr1loc, chr2loc, unit, binsize)
 }
 

--- a/R/man/straw.Rd
+++ b/R/man/straw.Rd
@@ -4,9 +4,10 @@
 \alias{straw}
 \title{Straw Quick Dump}
 \usage{
-straw(norm, fname, chr1loc, chr2loc, unit, binsize)
+straw(matrix, norm, fname, chr1loc, chr2loc, unit, binsize)
 }
 \arguments{
+\item{matrix}{Type of matrix to output. Must be one of observed/oe. observed is observed counts, oe is observed/expected counts.}
 \item{norm}{Normalization to apply. Must be one of NONE/VC/VC_SQRT/KR.
 VC is vanilla coverage, VC_SQRT is square root of vanilla coverage, and KR is Knight-Ruiz or
 Balanced normalization.}
@@ -33,5 +34,5 @@ of data, and outputs as data.frame in sparse upper triangular format.
 Currently only supporting matrices.
 }
 \details{
-Usage: straw <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>
+Usage: straw <observed/oe> <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>
 }

--- a/R/src/RcppExports.cpp
+++ b/R/src/RcppExports.cpp
@@ -6,24 +6,25 @@
 using namespace Rcpp;
 
 // straw
-Rcpp::DataFrame straw(std::string norm, std::string fname, std::string chr1loc, std::string chr2loc, std::string unit, int binsize);
-RcppExport SEXP _strawr_straw(SEXP normSEXP, SEXP fnameSEXP, SEXP chr1locSEXP, SEXP chr2locSEXP, SEXP unitSEXP, SEXP binsizeSEXP) {
+Rcpp::DataFrame straw(std::string matrix, std::string norm, std::string fname, std::string chr1loc, std::string chr2loc, std::string unit, int binsize);
+RcppExport SEXP _strawr_straw(SEXP matrixSEXP, SEXP normSEXP, SEXP fnameSEXP, SEXP chr1locSEXP, SEXP chr2locSEXP, SEXP unitSEXP, SEXP binsizeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type matrix(matrixSEXP);
     Rcpp::traits::input_parameter< std::string >::type norm(normSEXP);
     Rcpp::traits::input_parameter< std::string >::type fname(fnameSEXP);
     Rcpp::traits::input_parameter< std::string >::type chr1loc(chr1locSEXP);
     Rcpp::traits::input_parameter< std::string >::type chr2loc(chr2locSEXP);
     Rcpp::traits::input_parameter< std::string >::type unit(unitSEXP);
     Rcpp::traits::input_parameter< int >::type binsize(binsizeSEXP);
-    rcpp_result_gen = Rcpp::wrap(straw(norm, fname, chr1loc, chr2loc, unit, binsize));
+    rcpp_result_gen = Rcpp::wrap(straw(matrix, norm, fname, chr1loc, chr2loc, unit, binsize));
     return rcpp_result_gen;
 END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_strawr_straw", (DL_FUNC) &_strawr_straw, 6},
+    {"_strawr_straw", (DL_FUNC) &_strawr_straw, 7},
     {NULL, NULL, 0}
 };
 

--- a/R/src/straw-R.cpp
+++ b/R/src/straw-R.cpp
@@ -77,7 +77,7 @@ bool readMagicString(ifstream& fin) {
 }
 
 // reads the header, storing the positions of the normalization vectors and returning the master pointer
-long readHeader(ifstream& fin, string chr1, string chr2, int &c1pos1, int &c1pos2, int &c2pos1, int &c2pos2, int &chr1ind, int &chr2ind) {
+long readHeader(ifstream& fin, string chr1, string chr2, int &c1pos1, int &c1pos2, int &c2pos1, int &c2pos2, int &chr1ind, int &chr2ind, int &chr1len, int &chr2len) {
   if (!readMagicString(fin)) {
     cerr << "Hi-C magic string is missing, does not appear to be a hic file" << endl;
     stop("\n");
@@ -115,6 +115,7 @@ long readHeader(ifstream& fin, string chr1, string chr2, int &c1pos1, int &c1pos
     if (name==chr1) {
       found1=true;
       chr1ind = i;
+      chr1len = length;
       if (c1pos1 == -100) {
 	c1pos1 = 0;
 	c1pos2 = length;
@@ -123,6 +124,7 @@ long readHeader(ifstream& fin, string chr1, string chr2, int &c1pos1, int &c1pos
     if (name==chr2) {
       found2=true;
       chr2ind = i;
+      chr2len = length;
       if (c2pos1 == -100) {
 	c2pos1 = 0;
 	c2pos2 = length;
@@ -140,7 +142,7 @@ long readHeader(ifstream& fin, string chr1, string chr2, int &c1pos1, int &c1pos
 // reads the footer from the master pointer location. takes in the chromosomes, norm, unit (BP or FRAG) and resolution or
 // binsize, and sets the file position of the matrix and the normalization vectors for those chromosomes at the given
 // normalization and resolution
-void readFooter(ifstream& fin, long master, int c1, int c2, string norm, string unit, int resolution, long &myFilePos, indexEntry &c1NormEntry, indexEntry &c2NormEntry) {
+void readFooter(ifstream& fin, long master, int c1, int c2, string norm, string unit, int resolution, long &myFilePos, indexEntry &c1NormEntry, indexEntry &c2NormEntry, vector<double> &expectedValues) {
   fin.seekg(master, ios::beg);
   int nBytes;
   fin.read((char*)&nBytes, sizeof(int));
@@ -184,9 +186,13 @@ void readFooter(ifstream& fin, long master, int c1, int c2, string norm, string 
 
     int nValues;
     fin.read((char*)&nValues, sizeof(int));
+    bool store = c1 == c2 && str == unit && binSize == resolution;
     for (int j=0; j<nValues; j++) {
       double v;
       fin.read((char*)&v, sizeof(double));
+      if (store) {
+        expectedValues.push_back(v);
+      }
     }
 
     int nNormalizationFactors;
@@ -196,7 +202,20 @@ void readFooter(ifstream& fin, long master, int c1, int c2, string norm, string 
       fin.read((char*)&chrIdx, sizeof(int));
       double v;
       fin.read((char*)&v, sizeof(double));
+      if (store && chrIdx == c1) {
+        for (vector<double>::iterator it=expectedValues.begin(); it!=expectedValues.end(); ++it) {
+          *it = *it / v;
+        }
+      }
     }
+  }
+  if (norm == "OE") {
+    if (c1 == c2 && expectedValues.size() == 0) {
+      cerr << "File did not contain expected values vectors at " << resolution << " " << unit << endl;
+      stop("\n");
+      // exit(1);
+    }
+    return;
   }
   fin.read((char*)&nExpectedValues, sizeof(int));
   for (int i=0; i<nExpectedValues; i++) {
@@ -257,13 +276,14 @@ void readFooter(ifstream& fin, long master, int c1, int c2, string norm, string 
 }
 
 // reads the raw binned contact matrix at specified resolution, setting the block bin count and block column count
-bool readMatrixZoomData(ifstream& fin, string myunit, int mybinsize, int &myBlockBinCount, int &myBlockColumnCount) {
+bool readMatrixZoomData(ifstream& fin, string myunit, int mybinsize, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount) {
   string unit;
   getline(fin, unit, '\0' ); // unit
   int tmp;
   fin.read((char*)&tmp, sizeof(int)); // Old "zoom" index -- not used
+  float sumCounts;
+  fin.read((char*)&sumCounts, sizeof(float)); // sumCounts
   float tmp2;
-  fin.read((char*)&tmp2, sizeof(float)); // sumCounts
   fin.read((char*)&tmp2, sizeof(float)); // occupiedCellCount
   fin.read((char*)&tmp2, sizeof(float)); // stdDev
   fin.read((char*)&tmp2, sizeof(float)); // percent95
@@ -276,6 +296,7 @@ bool readMatrixZoomData(ifstream& fin, string myunit, int mybinsize, int &myBloc
 
   bool storeBlockData = false;
   if (myunit==unit && mybinsize==binSize) {
+    mySumCounts = sumCounts;
     myBlockBinCount = blockBinCount;
     myBlockColumnCount = blockColumnCount;
     storeBlockData = true;
@@ -301,7 +322,7 @@ bool readMatrixZoomData(ifstream& fin, string myunit, int mybinsize, int &myBloc
 
 // goes to the specified file pointer and finds the raw contact matrix at specified resolution, calling readMatrixZoomData.
 // sets blockbincount and blockcolumncount
-void readMatrix(ifstream& fin, long myFilePosition, string unit, int resolution, int &myBlockBinCount, int &myBlockColumnCount) {
+void readMatrix(ifstream& fin, long myFilePosition, string unit, int resolution, float &mySumCounts, int &myBlockBinCount, int &myBlockColumnCount) {
   fin.seekg(myFilePosition, ios::beg);
   int c1,c2;
   fin.read((char*)&c1, sizeof(int)); //chr1
@@ -311,7 +332,7 @@ void readMatrix(ifstream& fin, long myFilePosition, string unit, int resolution,
   int i=0;
   bool found=false;
   while (i<nRes && !found) {
-    found = readMatrixZoomData(fin, unit, resolution, myBlockBinCount, myBlockColumnCount);
+    found = readMatrixZoomData(fin, unit, resolution, mySumCounts, myBlockBinCount, myBlockColumnCount);
     i++;
   }
   if (!found) {
@@ -481,7 +502,7 @@ vector<contactRecord> readBlock(ifstream& fin, int blockNumber) {
       }
     }
   }
-  delete uncompressedBytes; // don't forget to delete your heap arrays in C++!
+  delete[] uncompressedBytes; // don't forget to delete your heap arrays in C++!
   return v;
 }
 
@@ -515,9 +536,9 @@ vector<double> readNormalizationVector(ifstream& fin, indexEntry entry) {
 //' Java version. Reads the .hic file, finds the appropriate matrix and slice
 //' of data, and outputs as data.frame in sparse upper triangular format.
 //' Currently only supporting matrices.
-//' 
+//'
 //' Usage: straw <NONE/VC/VC_SQRT/KR> <hicFile(s)> <chr1>[:x1:x2] <chr2>[:y1:y2] <BP/FRAG> <binsize>
-//' 
+//'
 //' @param norm Normalization to apply. Must be one of NONE/VC/VC_SQRT/KR.
 //'     VC is vanilla coverage, VC_SQRT is square root of vanilla coverage, and KR is Knight-Ruiz or
 //'     Balanced normalization.
@@ -548,6 +569,7 @@ Rcpp::DataFrame straw(std::string norm, std::string fname, std::string chr1loc, 
   stringstream ss(chr1loc);
   string chr1, chr2, x, y;
   int c1pos1=-100, c1pos2=-100, c2pos1=-100, c2pos2=-100;
+  int chr1len, chr2len;
   getline(ss, chr1, ':');
   if (getline(ss, x, ':') && getline(ss, y, ':')) {
     c1pos1 = stoi(x);
@@ -560,7 +582,7 @@ Rcpp::DataFrame straw(std::string norm, std::string fname, std::string chr1loc, 
     c2pos2 = stoi(y);
   }
   int chr1ind, chr2ind;
-  long master = readHeader(fin, chr1, chr2, c1pos1, c1pos2, c2pos1, c2pos2, chr1ind, chr2ind);
+  long master = readHeader(fin, chr1, chr2, c1pos1, c1pos2, c2pos1, c2pos2, chr1ind, chr2ind, chr1len, chr2len);
 
   int c1=min(chr1ind,chr2ind);
   int c2=max(chr1ind,chr2ind);
@@ -590,20 +612,28 @@ Rcpp::DataFrame straw(std::string norm, std::string fname, std::string chr1loc, 
 
   indexEntry c1NormEntry, c2NormEntry;
   long myFilePos;
+  vector<double> expectedValues;
 
   // readFooter will assign the above variables
-  readFooter(fin, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry);
+  readFooter(fin, master, c1, c2, norm, unit, binsize, myFilePos, c1NormEntry, c2NormEntry, expectedValues);
 
   vector<double> c1Norm;
   vector<double> c2Norm;
 
-  if (norm != "NONE") {
+  if (norm != "OE" && norm != "NONE") {
     c1Norm = readNormalizationVector(fin, c1NormEntry);
     c2Norm = readNormalizationVector(fin, c2NormEntry);
   }
+  float sumCounts;
   int blockBinCount, blockColumnCount;
-  // readMatrix will assign blockBinCount and blockColumnCount
-  readMatrix(fin, myFilePos, unit, binsize, blockBinCount, blockColumnCount);
+  // readMatrix will assign sumCounts, blockBinCount, and blockColumnCount
+  readMatrix(fin, myFilePos, unit, binsize, sumCounts, blockBinCount, blockColumnCount);
+  double avgCount;
+  if (c1 != c2) {
+    long nBins1 = chr1len / binsize;
+    long nBins2 = chr2len / binsize;
+    avgCount = (sumCounts / nBins1) / nBins2;   // <= trying to avoid overflows
+  }
 
   set<int> blockNumbers = getBlockNumbersForRegionFromBinPosition(regionIndices, blockBinCount, blockColumnCount, c1==c2);
 
@@ -620,8 +650,16 @@ Rcpp::DataFrame straw(std::string norm, std::string fname, std::string chr1loc, 
       int xActual = rec.binX * binsize;
       int yActual = rec.binY * binsize;
       float counts = rec.counts;
-      if (norm != "NONE") {
-	counts = counts / (c1Norm[rec.binX] * c2Norm[rec.binY]);
+      if (norm == "OE") {
+        if (c1 == c2) {
+          counts = counts / expectedValues[min(expectedValues.size() - 1, (size_t)floor(abs(yActual - xActual) / binsize))];
+        }
+        else {
+          counts = counts / avgCount;
+        }
+      }
+      else if (norm != "NONE") {
+        counts = counts / (c1Norm[rec.binX] * c2Norm[rec.binY]);
       }
 //      cout << xActual << " " << yActual << " " << counts << endl;
       if ((xActual >= origRegionIndices[0] && xActual <= origRegionIndices[1] &&


### PR DESCRIPTION
I added a `matrix` parameter that takes either `observed` or `oe` to behave more like juicer dump. I ran several tests to confirm the results matched those of juicer dump. I only modified the C++ executable and R library strawr (and underlying C++); not the Python.