### PR TITLE
Fix for rwinlib ucrt binaries

### DIFF
--- a/R/src/Makevars.ucrt
+++ b/R/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/R/src/Makevars.win
+++ b/R/src/Makevars.win
@@ -1,5 +1,5 @@
 VERSION=7.64.1
-PKG_LIBS= -L../windows/libcurl-$(VERSION)/lib${R_ARCH} \
+PKG_LIBS= -L../windows/libcurl-$(VERSION)/lib${R_ARCH}${CRT} \
 	-lwinhttp -lcurl -lssh2 -lz -lssl -lcrypto -lgdi32 -lws2_32 -lcrypt32 -lwldap32
 
 PKG_CPPFLAGS= \


### PR DESCRIPTION
Hello I maintain the rwinlib binaries.

Here is a small tweak needed for compatibility with the new ucrt compilers, see upstream: https://github.com/jeroen/curl/commit/5226cd86a2848947d850f3adafef95980202255e