### PR TITLE
Fix for URL files (particularly on Mac), adapt auxiliary R functions for URL files, and update version numbers

### DIFF
--- a/C++/straw.cpp
+++ b/C++/straw.cpp
@@ -859,10 +859,13 @@ public:
         size_t numbytes = size * nitems;
         b[numbytes + 1] = '\0';
         string s(b);
-        int32_t found = static_cast<int32_t>(s.find("Content-Range"));
+        int32_t found = static_cast<int32_t>(s.find("content-range"));
+        if ((size_t)found == string::npos) {
+          found = static_cast<int32_t>(s.find("Content-Range"));
+        }
         if ((size_t)found != string::npos) {
             int32_t found2 = static_cast<int32_t>(s.find("/"));
-            //Content-Range: bytes 0-100000/891471462
+            //content-range: bytes 0-100000/891471462
             if ((size_t)found2 != string::npos) {
                 string total = s.substr(found2 + 1);
                 totalFileSize = stol(total);

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: strawr
 Title: Fast Implementation of Reading/Dump for .hic Files
-Version: 0.0.8
+Version: 0.0.9
 Authors@R:
   c(person("Neva", c("Cherniavsky", "Durand"), email = "neva@broadinstitute.org", role = c("aut", "cre")),
     person(c("Muhammad", "Saad"), "Shamim", email = "sa501428@gmail.com", role = "aut"),

--- a/R/src/straw.cpp
+++ b/R/src/straw.cpp
@@ -837,10 +837,13 @@ public:
         size_t numbytes = size * nitems;
         b[numbytes + 1] = '\0';
         string s(b);
-        int32_t found = static_cast<int32_t>(s.find("Content-Range"));
+        int32_t found = static_cast<int32_t>(s.find("content-range"));
+        if ((size_t)found == string::npos) {
+          found = static_cast<int32_t>(s.find("Content-Range"));
+        }
         if ((size_t)found != string::npos) {
             int32_t found2 = static_cast<int32_t>(s.find("/"));
-            //Content-Range: bytes 0-100000/891471462
+            //content-range: bytes 0-100000/891471462
             if ((size_t)found2 != string::npos) {
                 string total = s.substr(found2 + 1);
                 totalFileSize = stol(total);

--- a/pybind11_python/src/straw.cpp
+++ b/pybind11_python/src/straw.cpp
@@ -861,10 +861,13 @@ public:
         size_t numbytes = size * nitems;
         b[numbytes + 1] = '\0';
         string s(b);
-        int32_t found = static_cast<int32_t>(s.find("Content-Range"));
+        int32_t found = static_cast<int32_t>(s.find("content-range"));
+        if ((size_t)found == string::npos) {
+          found = static_cast<int32_t>(s.find("Content-Range"));
+        }
         if ((size_t)found != string::npos) {
             int32_t found2 = static_cast<int32_t>(s.find("/"));
-            //Content-Range: bytes 0-100000/891471462
+            //content-range: bytes 0-100000/891471462
             if ((size_t)found2 != string::npos) {
                 string total = s.substr(found2 + 1);
                 totalFileSize = stol(total);

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="hic-straw",
-    version="0.0.8",
+    version="0.0.9",
     author="Neva C. Durand",
     email="theaidenlab@gmail.com",
     description="Extract data quickly from Juicebox hic files via straw",


### PR DESCRIPTION
- Not sure when this happened but at some point, particularly on Mac, it seems the HTTP file header changed from `Content-Range` to `content-range`. This broke support for URL files. I added logic to handle either case.
- Made the auxiliary R functions `readHicChroms` and `readHicBpResolutions` work on URL files. Previously only worked on local files.
- Updated version numbers from 0.0.8 to 0.0.9.