### PR TITLE
optimize out temporary matrix from getRecordsAsMatrix()

### DIFF
--- a/C++/straw.cpp
+++ b/C++/straw.cpp
@@ -1391,11 +1391,9 @@ public:
         int64_t endC = regionIndices[3];
         int32_t numRows = endR - originR + 1;
         int32_t numCols = endC - originC + 1;
-        float matrix[numRows][numCols];
-        for(int32_t r = 0; r < numRows; r++){
-            for(int32_t c = 0; c < numCols; c++){
-                matrix[r][c] = 0;
-            }
+        vector<vector<float> > matrix;
+        for (int32_t i = 0; i < numRows; i++) {
+            matrix.emplace_back(numCols, 0);
         }
 
         for (contactRecord cr : records) {
@@ -1413,17 +1411,7 @@ public:
                 }
             }
         }
-
-        vector<vector<float> > finalMatrix;
-        for (int32_t i = 0; i < numRows; i++) {
-            vector<float> row;
-            row.reserve(numCols);
-            for (int32_t j = 0; j < numCols; j++) {
-                row.push_back(matrix[i][j]);
-            }
-            finalMatrix.push_back(row);
-        }
-        return finalMatrix;
+        return matrix;
     }
 
     int64_t getNumberOfTotalRecords() {

--- a/pybind11_python/src/straw.cpp
+++ b/pybind11_python/src/straw.cpp
@@ -1395,11 +1395,9 @@ public:
         int64_t endC = regionIndices[3];
         int32_t numRows = endR - originR + 1;
         int32_t numCols = endC - originC + 1;
-        float matrix[numRows][numCols];
-        for(int32_t r = 0; r < numRows; r++){
-            for(int32_t c = 0; c < numCols; c++){
-                matrix[r][c] = 0;
-            }
+        vector<vector<float> > matrix;
+        for (int32_t i = 0; i < numRows; i++) {
+            matrix.emplace_back(numCols, 0);
         }
 
         for (contactRecord cr : records) {
@@ -1417,17 +1415,7 @@ public:
                 }
             }
         }
-
-        vector<vector<float>> finalMatrix;
-        for (int32_t i = 0; i < numRows; i++) {
-            vector<float> row;
-            row.reserve(numCols);
-            for (int32_t j = 0; j < numCols; j++) {
-                row.push_back(matrix[i][j]);
-            }
-            finalMatrix.push_back(row);
-        }
-        return py::array(py::cast(finalMatrix));
+        return py::array(py::cast(matrix));
     }
 
     int64_t getNumberOfTotalRecords() {


### PR DESCRIPTION
This change removes a temporary matrix previously used in MatrixZoomData::getRecordsAsMatrix(), instead directly writing into the vector of vectors that is ultimately expected to be returned.