### PR TITLE
Use rtools43 libcurl when available, fixes arm64 builds

### DIFF
--- a/R/src/Makevars.ucrt
+++ b/R/src/Makevars.ucrt
@@ -1,2 +1,9 @@
-CRT=-ucrt
-include Makevars.win
+# Used on rtools43 and up
+PKG_CPPFLAGS = -DCURL_STATICLIB
+PKG_LIBS = $(shell pkg-config --libs libcurl)
+
+# Fallback for older rtools without pkgconfig
+ifeq (,$(PKG_LIBS))
+  CRT=-ucrt
+  include Makevars.win
+endif


### PR DESCRIPTION
Hello! I maintain the libraries on [rwinlib/curl](https://github.com/rwinlib/curl) that your package downloads.

For new versions of R, your package should be locating libcurl on Windows this new way. 

You should try to submit this to CRAN soon; this will fix the build on arm64 on Windows. 